### PR TITLE
Config objects

### DIFF
--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -696,26 +696,26 @@ class Config(object):
 		
 		imagePlacing.name = imagePlacingName
 			
-		imagePlacing.fileTypesForGameList, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForGameList', tree)		
-		imagePlacing.fileTypesForGameListSelected, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForGameListSelected', tree)
-		imagePlacing.fileTypesForMainView1, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainView1', tree)
-		imagePlacing.fileTypesForMainView2, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainView2', tree)
-		imagePlacing.fileTypesForMainView3, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainView3', tree)
-		imagePlacing.fileTypesForMainViewBackground, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewBackground', tree)
-		imagePlacing.fileTypesForMainViewGameInfoBig, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoBig', tree)
-		imagePlacing.fileTypesForMainViewGameInfoUpperLeft, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoUpperLeft', tree)
-		imagePlacing.fileTypesForMainViewGameInfoUpperRight, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoUpperRight', tree)
-		imagePlacing.fileTypesForMainViewGameInfoLowerLeft, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLowerLeft', tree)
-		imagePlacing.fileTypesForMainViewGameInfoLowerRight, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLowerRight', tree)
+		imagePlacing.fileTypesForGameList = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForGameList', tree)
+		imagePlacing.fileTypesForGameListSelected = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForGameListSelected', tree)
+		imagePlacing.fileTypesForMainView1 = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainView1', tree)
+		imagePlacing.fileTypesForMainView2 = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainView2', tree)
+		imagePlacing.fileTypesForMainView3 = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainView3', tree)
+		imagePlacing.fileTypesForMainViewBackground = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewBackground', tree)
+		imagePlacing.fileTypesForMainViewGameInfoBig = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoBig', tree)
+		imagePlacing.fileTypesForMainViewGameInfoUpperLeft = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoUpperLeft', tree)
+		imagePlacing.fileTypesForMainViewGameInfoUpperRight = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoUpperRight', tree)
+		imagePlacing.fileTypesForMainViewGameInfoLowerLeft = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLowerLeft', tree)
+		imagePlacing.fileTypesForMainViewGameInfoLowerRight = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLowerRight', tree)
 		
-		imagePlacing.fileTypesForMainViewGameInfoLower, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLower', tree)
-		imagePlacing.fileTypesForMainViewGameInfoUpper, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoUpper', tree)
-		imagePlacing.fileTypesForMainViewGameInfoRight, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoRight', tree)
-		imagePlacing.fileTypesForMainViewGameInfoLeft, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLeft', tree)
+		imagePlacing.fileTypesForMainViewGameInfoLower = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLower', tree)
+		imagePlacing.fileTypesForMainViewGameInfoUpper = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoUpper', tree)
+		imagePlacing.fileTypesForMainViewGameInfoRight = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoRight', tree)
+		imagePlacing.fileTypesForMainViewGameInfoLeft = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewGameInfoLeft', tree)
 		
-		imagePlacing.fileTypesForMainViewVideoWindowBig, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewVideoWindowBig', tree)
-		imagePlacing.fileTypesForMainViewVideoWindowSmall, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewVideoWindowSmall', tree)
-		imagePlacing.fileTypesForMainViewVideoFullscreen, errorMsg = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewVideoFullscreen', tree)
+		imagePlacing.fileTypesForMainViewVideoWindowBig = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewVideoWindowBig', tree)
+		imagePlacing.fileTypesForMainViewVideoWindowSmall = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewVideoWindowSmall', tree)
+		imagePlacing.fileTypesForMainViewVideoFullscreen = self.readFileTypeForElement(fileTypeForRow, 'fileTypeForMainViewVideoFullscreen', tree)
 			
 		return imagePlacing, ''
 	
@@ -726,11 +726,11 @@ class Config(object):
 				
 			fileType, errorMsg = self.readFileType(fileTypeForControl.text, tree)
 			if fileType is None:
-				return None, errorMsg
+				return None
 						
 			fileTypeList.append(fileType)
 				
-		return fileTypeList, ''
+		return fileTypeList
 	
 	def readMissingFilter(self, filterName, tree):
 		missingFilter = MissingFilter()

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -211,24 +211,59 @@ class MediaPath(object):
 	def __repr__(self):
 		return "<MediaPath: %s>" % self.__dict__
 	
-class Scraper:
-	parseInstruction = ''
-	source = ''
-	sourceAppend = ''
-	encoding = 'utf-8'
-	returnUrl = False
-	replaceKeyString = ''
-	replaceValueString = ''
-	
-class Site:
-	name = ''	
-	descFilePerGame = False
-	searchGameByCRC = True
-	searchGameByCRCIgnoreRomName = False
-	useFoldernameAsCRC = False
-	useFilenameAsCRC = False
-	
-	scrapers = None
+class Scraper(object):
+	"""
+	A scraper represents the details of how to interpret the XML response from a site to extract the game's
+	metadata.
+
+	parseInstruction: Name of the XML file which details how to interpret the XML response. The XML files are
+	contained in the scraper/ directory.
+	source: URL to retrieve the element in question, with placeholders defined.
+	sourceAppend:
+	encoding: Expected encoding of the site, defaults to 'utf-8' unless overridden.
+	returnUrl:
+	replaceKeyString:
+	replaceValueString:
+	"""
+	def __init__(self):
+		self.parseInstruction = ''
+		self.source = ''
+		self.sourceAppend = ''
+		self.encoding = 'utf-8'
+		self.returnUrl = False
+		self.replaceKeyString = ''
+		self.replaceValueString = ''
+
+	def __repr__(self):
+		return "<Scraper: %s>" % self.__dict__
+
+class Site(object):
+	"""
+	A site represents a source of metadata for the rom collections, e.g. giantbomb.com, local NFO.
+
+	These are defined in config_template.xml.
+
+	name: The name of the site
+	descFilePerGame:
+	searchGameByCRC: Use CRC of the rom to match, rather than the rom's title.
+	searchGameByCRCIgnoreRomName: This doesn't appear to be used at the moment.
+	useFoldernameAsCRC: Generate CRC based on the foldername
+	useFilenameAsCRC: Generate CRC based on the filename
+
+	scrapers: A list of Scraper objects which are the default for this site.
+	"""
+	def __init__(self):
+		self.name = ''
+		self.descFilePerGame = False
+		self.searchGameByCRC = True
+		self.searchGameByCRCIgnoreRomName = False
+		self.useFoldernameAsCRC = False
+		self.useFilenameAsCRC = False
+
+		self.scrapers = []
+
+	def __repr__(self):
+		return "<Site: %s>" % self.__dict__
 	
 
 class MissingFilter:

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -266,10 +266,13 @@ class Site(object):
 		return "<Site: %s>" % self.__dict__
 	
 
-class MissingFilter:
-	andGroup = []
-	orGroup = []
+class MissingFilter(object):
+	def __init__(self):
+		self.andGroup = []
+		self.orGroup = []
 
+	def __repr__(self):
+		return "<MissingFilter: %s>" % self.__dict__
 
 class RomCollection(object):
 	"""
@@ -862,4 +865,4 @@ class Config(object):
 			Logutil.log('%s: %s' %(elementName, element.text), util.LOG_LEVEL_INFO)
 			return element.text
 		else:
-			return ''
+			return ''

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -567,8 +567,8 @@ class Config(object):
 			romCollection.diskPrefix = romCollectionRow.findtext('diskPrefix', '')
 
 			# RomCollection bool properties
-			romCollection.allowUpdate = romCollectionRow.findtext('useBuiltinEmulator', '').upper() == 'TRUE'
-			romCollection.allowUpdate = romCollectionRow.findtext('ignoreOnScan', '').upper() == 'TRUE'
+			romCollection.useBuiltinEmulator = romCollectionRow.findtext('useBuiltinEmulator', '').upper() == 'TRUE'
+			romCollection.ignoreOnScan = romCollectionRow.findtext('ignoreOnScan', '').upper() == 'TRUE'
 			romCollection.allowUpdate = romCollectionRow.findtext('allowUpdate', '').upper() == 'TRUE'
 			romCollection.useEmuSolo = romCollectionRow.findtext('useEmuSolo', '').upper() == 'TRUE'
 			romCollection.usePopen = romCollectionRow.findtext('usePopen', '').upper() == 'TRUE'

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -194,9 +194,22 @@ class ImagePlacing:
 	fileTypesForMainViewVideoWindowSmall = None
 	fileTypesForMainViewVideoFullscreen = None
 	
-class MediaPath:
-	path = ''
-	fileType = None
+class MediaPath(object):
+	"""
+	A RomCollection has multiple MediaPaths, each one representing different artwork
+	e.g. boxfront, boxback, etc. The fileType is a FileType object.
+
+	Note MediaPath can also be used for RomCollections, Publishers and Developers.
+
+	path: The filesystem path to the Media
+	fileType: The FileType object referenced by the path
+	"""
+	def __init__(self):
+		self.path = ''
+		self.fileType = None
+
+	def __repr__(self):
+		return "<MediaPath: %s>" % self.__dict__
 	
 class Scraper:
 	parseInstruction = ''

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -332,24 +332,38 @@ class RomCollection(object):
 		return "<RomCollection: %s>" % self.__dict__
 
 
-class Config:
-		
-	romCollections = None
-	scraperSites = None
+class Config(object):
+	"""
+	romCollections: A list of all the RomCollections added by the user
+	scraperSites: A list of all the available Sites/Scrapers
 	fileTypeIdsForGamelist = None
 	
-	showHideOption = 'ignore'
-	missingFilterInfo = None
-	missingFilterArtwork = None
+	showHideOption: Default is 'ignore'
+	missingFilterInfo:
+	missingFilterArtwork:
 	
-	tree = None
-	configPath = None
-	
+	tree: XML tree containing the configuration
+	configPath: This doesn't appear to be used
+	configFile: Path to the XML tree
+	"""
 	
 	def __init__(self, configFile):
+		self.romCollections = None
+		self.scraperSites = None
+		self.fileTypeIdsForGamelist = None
+
+		self.showHideOption = 'ignore'
+		self.missingFilterInfo = None
+		self.missingFilterArtwork = None
+
+		self.tree = None
+		self.configPath = None
+
 		Logutil.log('Config() set path to %s' %configFile, util.LOG_LEVEL_INFO)
 		self.configFile = configFile
 
+	def __repr__(self):
+		return "<Config: %s>" % self.__dict__
 	
 	def initXml(self):
 		Logutil.log('initXml', util.LOG_LEVEL_INFO)

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -153,11 +153,24 @@ imagePlacingDict = {'gameinfobig' : 'one big',
 					'gameinfomamecabinet' : 'MAME: cabinet in list'}			
 
 
-class FileType:
-	name = ''
-	id = -1
-	type = ''
-	parent = ''
+class FileType(object):
+	"""
+	This config object is defined in config_template.xml in element FileTypes.
+
+	name: In the case of MAME, this will be either: boxfront, cabinet, marquee, action, title.
+	      For all other emulators: boxfront, boxback, cartridge, screenshot, fanart.
+	id: Unique identifier for the FileType, defined in config_template.xml, and used in the File table in the database.
+	type: The filetype, either image or video.
+	parent: The class that this file pertains to. Current supported values: game, romcollection, developer, publisher.
+	"""
+	def __init__(self):
+		self.name = ''
+		self.id = -1
+		self.type = ''
+		self.parent = ''
+
+	def __repr__(self):
+		return "<FileType: %s>" % self.__dict__
 	
 class ImagePlacing:	
 	name = ''	

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -556,31 +556,16 @@ class Config(object):
 				romCollection.imagePlacingInfo = fileTypeFor
 						
 			# RomCollection properties
-			romCollection.gameclient = romCollectionRow.findtext('gameclient', '')
-			romCollection.emulatorCmd = romCollectionRow.findtext('emulatorCmd', '')
-
-			romCollection.preCmd = romCollectionRow.findtext('preCmd', '')
-			romCollection.postCmd = romCollectionRow.findtext('postCmd', '')
-			romCollection.emulatorParams = romCollectionRow.findtext('emulatorParams', '')
-			romCollection.saveStatePath = romCollectionRow.findtext('saveStatePath', '')
-			romCollection.saveStateParams = romCollectionRow.findtext('saveStateParams', '')
-			romCollection.diskPrefix = romCollectionRow.findtext('diskPrefix', '')
+			for var in ['gameclient', 'emulatorCmd', 'preCmd', 'postCmd', 'emulatorParams', 'saveStatePath',
+						'saveStateParams', 'diskPrefix']:
+				romCollection.__setattr__(var, romCollectionRow.findtext(var, ''))
 
 			# RomCollection bool properties
-			romCollection.useBuiltinEmulator = romCollectionRow.findtext('useBuiltinEmulator', '').upper() == 'TRUE'
-			romCollection.ignoreOnScan = romCollectionRow.findtext('ignoreOnScan', '').upper() == 'TRUE'
-			romCollection.allowUpdate = romCollectionRow.findtext('allowUpdate', '').upper() == 'TRUE'
-			romCollection.useEmuSolo = romCollectionRow.findtext('useEmuSolo', '').upper() == 'TRUE'
-			romCollection.usePopen = romCollectionRow.findtext('usePopen', '').upper() == 'TRUE'
-			romCollection.autoplayVideoMain = romCollectionRow.findtext('autoplayVideoMain', '').upper() == 'TRUE'
-			romCollection.autoplayVideoInfo = romCollectionRow.findtext('autoplayVideoInfo', '').upper() == 'TRUE'
-			romCollection.useFoldernameAsGamename = romCollectionRow.findtext('useFoldernameAsGamename', '').upper() == 'TRUE'
-			romCollection.maxFolderDepth = romCollectionRow.findtext('maxFolderDepth', '').upper() == 'TRUE'
-			romCollection.doNotExtractZipFiles = romCollectionRow.findtext('doNotExtractZipFiles', '').upper() == 'TRUE'
-			romCollection.makeLocalCopy = romCollectionRow.findtext('makeLocalCopy', '').upper() == 'TRUE'
-			romCollection.xboxCreateShortcut = romCollectionRow.findtext('xboxCreateShortcut', '').upper() == 'TRUE'
-			romCollection.xboxCreateShortcutAddRomfile = romCollectionRow.findtext('xboxCreateShortcutAddRomfile', '').upper() == 'TRUE'
-			romCollection.xboxCreateShortcutUseShortGamename = romCollectionRow.findtext('xboxCreateShortcutUseShortGamename', '').upper() == 'TRUE'
+			for var in ['useBuiltinEmulator', 'ignoreOnScan', 'allowUpdate', 'useEmuSolo', 'usePopen',
+						'autoplayVideoMain', 'autoplayVideoInfo', 'useFoldernameAsGamename', 'maxFolderDepth',
+						'doNotExtractZipFiles', 'makeLocalCopy', 'xboxCreateShortcut',
+						'xboxCreateShortcutAddRomfile', 'xboxCreateShortcutUseShortGamename']:
+				romCollection.__setattr__(var, romCollectionRow.findtext(var, '').upper() == 'TRUE')
 
 			# Add to dict
 			romCollections[id] = romCollection
@@ -608,11 +593,9 @@ class Config(object):
 		site.name = siteRow.attrib.get('name')
 		Logutil.log('Parsing scraper site: ' +str(site.name), util.LOG_LEVEL_INFO)
 
-		site.descFilePerGame = siteRow.get('descFilePerGame', '').upper() == 'TRUE'
-		site.searchGameByCRC = siteRow.get('searchGameByCRC', '').upper() == 'TRUE'
-		site.searchGameByCRCIgnoreRomName = siteRow.get('searchGameByCRCIgnoreRomName', '').upper() == 'TRUE'
-		site.useFoldernameAsCRC = siteRow.get('useFoldernameAsCRC', '').upper() == 'TRUE'
-		site.useFilenameAsCRC = siteRow.get('useFilenameAsCRC', '').upper() == 'TRUE'
+		for var in ['descFilePerGame', 'searchGameByCRC', 'searchGameByCRCIgnoreRomName',
+					'useFoldernameAsCRC', 'useFilenameAsCRC']:
+			site.__setattr__(var, siteRow.get(var, '').upper() == 'TRUE')
 
 		scrapers = []
 
@@ -643,7 +626,6 @@ class Config(object):
 			scraper.encoding = scraperRow.get('encoding', 'utf-8')
 			scraper.returnUrl = scraperRow.get('returnUrl', '').upper() == 'TRUE'
 			scraper.sourceAppend = scraperRow.get('sourceAppend', '')
-
 				
 			scraper.replaceKeyString = inReplaceKeyString
 			scraper.replaceValueString = inReplaceValueString

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -270,37 +270,66 @@ class MissingFilter:
 	andGroup = []
 	orGroup = []
 
-class RomCollection:
-	id = -1
-	name = ''
-	
-	useBuiltinEmulator = False
-	gameclient = ''
-	emulatorCmd = ''
-	preCmd = ''
-	postCmd = ''
-	emulatorParams = ''
-	romPaths = None
-	saveStatePath = ''
-	saveStateParams = ''
-	mediaPaths = None
-	scraperSites = None
-	imagePlacingMain = None
-	imagePlacingInfo = None
-	autoplayVideoMain = True
-	autoplayVideoInfo = True
-	ignoreOnScan = False
-	allowUpdate = True
-	useEmuSolo = False
-	usePopen = False
-	maxFolderDepth = 99
-	useFoldernameAsGamename = False
-	doNotExtractZipFiles = False
-	makeLocalCopy = False
-	diskPrefix = '_Disk.*'
-	xboxCreateShortcut = False
-	xboxCreateShortcutAddRomfile = False
-	xboxCreateShortcutUseShortGamename = False
+
+class RomCollection(object):
+	"""
+	useBuiltinEmulator: Use Kodi's libretro core, rather than an external emulator
+	gameclient: Select libretro gameclient manually
+	emulatorCmd: The OS command to launch the emulator
+	preCmd: The OS command to execute before the emulatorCmd
+	postCmd: The OS command to execute after the emulatorCmd
+	emulatorParams: List of command-line parameters appended to the emulatorCmd
+	romPaths:
+	ignoreOnScan: Whether to skip this rom collection when scanning
+	allowUpdate: Allows overwriting an existing rom in the collection with details from a more recent scan
+	useEmuSolo: Whether to shutdown/restart Kodi while running the external emulator using the scripts in
+	    scriptfiles/
+	usePopen: Use Python subprocess popen
+	maxFolderDepth: How many directories to recurse from the romPath looking for matching roms
+	useFoldernameAsGamename:
+	doNotExtractZipFiles: If the rom is a zip file, extract it to a temporary local directory. Used in
+	    cases of unsupported zip files (usually .7z)
+	makeLocalCopy: Whether to copy the rom to a temporary local directory and use that in the launch. Used
+	    primarily to workaround SMB issues
+	diskPrefix: String used to assist in identifying whether a romset has multiple files (representing a
+	    multi-disk game).
+	"""
+	def __init__(self):
+		self.id = -1
+		self.name = ''
+
+		self.useBuiltinEmulator = False
+		self.gameclient = ''
+		self.emulatorCmd = ''
+		self.preCmd = ''
+		self.postCmd = ''
+		self.emulatorParams = ''
+		self.romPaths = None
+		self.saveStatePath = ''
+		self.saveStateParams = ''
+		self.mediaPaths = None
+		self.scraperSites = None
+		self.imagePlacingMain = None
+		self.imagePlacingInfo = None
+		self.autoplayVideoMain = True
+		self.autoplayVideoInfo = True
+		self.ignoreOnScan = False
+		self.allowUpdate = True
+		self.useEmuSolo = False
+		self.usePopen = False
+		self.maxFolderDepth = 99
+		self.useFoldernameAsGamename = False
+		self.doNotExtractZipFiles = False
+		self.makeLocalCopy = False
+		self.diskPrefix = '_Disk.*'
+
+		# These are used for XBox, which is now legacy and no longer supported by Kodi
+		self.xboxCreateShortcut = False
+		self.xboxCreateShortcutAddRomfile = False
+		self.xboxCreateShortcutUseShortGamename = False
+
+	def __repr__(self):
+		return "<RomCollection: %s>" % self.__dict__
 
 
 class Config:
@@ -320,7 +349,7 @@ class Config:
 	def __init__(self, configFile):
 		Logutil.log('Config() set path to %s' %configFile, util.LOG_LEVEL_INFO)
 		self.configFile = configFile
-				
+
 	
 	def initXml(self):
 		Logutil.log('initXml', util.LOG_LEVEL_INFO)
@@ -396,7 +425,17 @@ class Config:
 	
 		
 	def readRomCollections(self, tree):
-		
+		"""
+		Parses the config XML tree and extract the RomCollection objects into a dict.
+
+		Args:
+		    tree: XML tree parsed from config.xml in the user's addon directory
+
+		Returns:
+		    A dict of the rom collections, with the id attribute as the key. If an error occurs
+		    parsing the tree, None is returned
+
+		"""
 		Logutil.log('Begin readRomCollections', util.LOG_LEVEL_INFO)
 		
 		romCollections = {}

--- a/resources/tests/test_config.py
+++ b/resources/tests/test_config.py
@@ -30,5 +30,15 @@ class TestConfig(unittest.TestCase):
         self.assertIsInstance(conf.romCollections, dict,
                               u'Expected dict object, was {0}'.format(type(conf.romCollections)))
 
+    def test_ParseValidConfigFileWithAllElements(self):
+        # Load a config file with 2 valid RomCollections and all FileTypes and ImagePlacings
+        config_xml_file = os.path.join(os.path.dirname(__file__), 'testdata', 'romcollections_two_valid.xml')
+        conf = Config(config_xml_file)
+        conf.readXml()
+
+        self.assertIsInstance(conf.romCollections, dict,
+                              u'Expected dict object, was {0}'.format(type(conf.romCollections)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/resources/tests/test_config.py
+++ b/resources/tests/test_config.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyparsing'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyscraper'))
+
+import unittest
+
+from config import Config
+import util
+from pprint import pprint
+
+class TestConfig(unittest.TestCase):
+    """
+    This unittest class is used for testing the parsing of the Config object
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # This is required so that readScraper() can parse the XML instruction files
+        util.RCBHOME = os.path.join(os.path.dirname(__file__), '..', '..')
+
+    def test_ParseValidConfigFile(self):
+        # Load a config file with 2 valid RomCollections
+        config_xml_file = os.path.join(os.path.dirname(__file__), 'testdata', 'romcollections_two_valid.xml')
+        conf = Config(config_xml_file)
+        conf.readXml()
+
+        self.assertIsInstance(conf.romCollections, dict,
+                              u'Expected dict object, was {0}'.format(type(conf.romCollections)))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/tests/test_config_filetype.py
+++ b/resources/tests/test_config_filetype.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyparsing'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyscraper'))
+
+import unittest
+
+from config import Config, FileType
+
+class TestFileType(unittest.TestCase):
+    """
+    This unittest class is used for testing the FileType object
+    """
+    def test_ParseValidFileIsSuccessful(self):
+        # Load the default config_template.xml distributed with RCB
+        configxmlfile = os.path.join(os.path.dirname(__file__), '..', 'database', 'config_template.xml')
+        conf = Config(configxmlfile)
+        conf.initXml()
+
+        ft, msg = conf.readFileType('gameplay', conf.tree)
+        self.assertIsInstance(ft, FileType, u'Expected FileType object')
+
+        self.assertTrue(ft.type == 'video')
+        self.assertTrue(ft.parent == 'game')
+        self.assertTrue(ft.id == '12')
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/tests/test_config_romcollection.py
+++ b/resources/tests/test_config_romcollection.py
@@ -52,16 +52,46 @@ class TestRomCollection(unittest.TestCase):
 
         # Get the NES rom collection
         rc = self.rom_collections['6']
+
+        # Validate lists for multiple elements
         self.assertTrue(len(rc.mediaPaths) == 5,
                         u'Expected 5 media paths for NES RomCollection, found {0}'.format(len(rc.mediaPaths)))
         self.assertTrue(len(rc.romPaths) == 2,
                         u'Expected 2 ROM paths for NES RomCollection, found {0}'.format(len(rc.romPaths)))
+        self.assertTrue(rc.name == 'NES', u'Expected collection name to be NES, was {0}'.format(rc.name))
+
+        # Validate boolean values
+        self.assertTrue(rc.useEmuSolo == False,
+                        u'Expected boolean value for boolean attribute, was {0}'.format(rc.useEmuSolo))
+        self.assertIsInstance(rc.useEmuSolo, bool,
+                              u'Expected boolean type for boolean attribute, was {0}'.format(type(rc.useEmuSolo)))
+        self.assertTrue(rc.allowUpdate == True,
+                        u'Expected boolean value for boolean attribute, was {0}'.format(rc.allowUpdate))
+
+        # Validate empty elements are empty strings
+        self.assertTrue(rc.gameclient == '', u'Expected collection gameclient to be \'\', was {0}'.format(rc.gameclient))
+
+        # Validate non-empty elements are as expected
+        self.assertTrue(rc.emulatorCmd == '/Path/To/NES/Emulator',
+                        u'Incorrect expected value for collection emulatorCmd ({0})'.format(rc.emulatorCmd))
 
         # Get the Atari2600 rom collection
         rc = self.rom_collections['7']
         self.assertTrue(len(rc.romPaths) == 1,
                         u'Expected 1 ROM paths for Atari2600 RomCollection, found {0}'.format(len(rc.romPaths)))
 
+    @unittest.skip('Skipping until parsing config.xml file returns only the valid collections instead of None')
+    def test_ParseCollectionWithMissingAttribsFails(self):
+        config_xml_file = os.path.join(os.path.dirname(__file__), 'testdata', 'romcollections_invalid_missingattribs.xml')
+        self.read_config_file(config_xml_file)
+
+        self.assertTrue(len(self.rom_collections) == 1,
+                        u'Expected 1 valid rom collection, found {0}'.format(len(self.rom_collections)))
+
+        # Get the valid SNES rom collection
+        rc = self.rom_collections['7']
+        self.assertIsInstance(rc, RomCollection, u'Expected RomCollection object, was {0}'.format(type(rc)))
+        self.assertTrue(rc.name == 'SNES', u'Expected RomCollection name to be SNES, was {0}'.format(rc.name))
 
 
 if __name__ == "__main__":

--- a/resources/tests/test_config_romcollection.py
+++ b/resources/tests/test_config_romcollection.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyparsing'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyscraper'))
+
+import unittest
+
+from config import Config, RomCollection
+import util
+
+class TestRomCollection(unittest.TestCase):
+    """
+    This unittest class is used for testing the parsing of the RomCollection
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # This is required so that readScraper() can parse the XML instruction files
+        util.RCBHOME = os.path.join(os.path.dirname(__file__), '..', '..')
+
+    @classmethod
+    def read_config_file(cls, config_xml_file):
+        """ This class function parses a specified XML. It is used by all the test cases as a setup.
+        """
+        conf = Config(config_xml_file)
+        conf.initXml()
+
+        # The config_template.xml file has no defined collections, so we expect an empty list
+        cls.rom_collections, cls.msg = conf.readRomCollections(conf.tree)
+
+    def test_ParseFileWithNoRomCollectionsReturnsNone(self):
+        # Load the default config_template.xml distributed with RCB
+        config_xml_file = os.path.join(os.path.dirname(__file__), '..', 'database', 'config_template.xml')
+        self.read_config_file(config_xml_file)
+
+        self.assertIsNone(self.rom_collections,
+                          u'Expected readRomCollections to return None, was {0}'.format(type(self.rom_collections)))
+
+    def test_ParseFileWithValidCollections(self):
+        config_xml_file = os.path.join(os.path.dirname(__file__), 'testdata', 'romcollections_two_valid.xml')
+        self.read_config_file(config_xml_file)
+
+        self.assertIsInstance(self.rom_collections, dict,
+                              u'Expected dict object, was {0}'.format(type(self.rom_collections)))
+
+        self.assertTrue(len(self.rom_collections) == 2,
+                        u'Expected 2 RomCollections, found {0} items'.format(self.rom_collections))
+
+        self.assertTrue('6' in self.rom_collections)
+
+        # Get the NES rom collection
+        rc = self.rom_collections['6']
+        self.assertTrue(len(rc.mediaPaths) == 5,
+                        u'Expected 5 media paths for NES RomCollection, found {0}'.format(len(rc.mediaPaths)))
+        self.assertTrue(len(rc.romPaths) == 2,
+                        u'Expected 2 ROM paths for NES RomCollection, found {0}'.format(len(rc.romPaths)))
+
+        # Get the Atari2600 rom collection
+        rc = self.rom_collections['7']
+        self.assertTrue(len(rc.romPaths) == 1,
+                        u'Expected 1 ROM paths for Atari2600 RomCollection, found {0}'.format(len(rc.romPaths)))
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/tests/test_config_scraper.py
+++ b/resources/tests/test_config_scraper.py
@@ -26,10 +26,10 @@ class TestScraper(unittest.TestCase):
         config_xml_file = os.path.join(os.path.dirname(__file__), '..', 'database', 'config_template.xml')
         conf = Config(config_xml_file)
         conf.initXml()
-        #self.assertTrue(conf is None, u'Expected conf to be none')
 
         sites, msg = conf.readScrapers(conf.tree)
-        self.assertIsInstance(sites, dict, u'Expected list object, was {0}'.format(type(sites)))
+
+        self.assertIsInstance(sites, dict, u'Expected dict object, was {0}'.format(type(sites)))
 
         l = len(sites)
         self.assertTrue(l == 6, u'Expected multiple scraper sites, found {0}'.format(l))

--- a/resources/tests/test_config_scraper.py
+++ b/resources/tests/test_config_scraper.py
@@ -34,9 +34,9 @@ class TestScraper(unittest.TestCase):
         l = len(sites)
         self.assertTrue(l == 6, u'Expected multiple scraper sites, found {0}'.format(l))
 
-        #self.assertTrue(scrapers['local nfo'].descFilePerGame == 'video')
-        #self.assertTrue(ft.parent == 'game')
-        #self.assertTrue(ft.id == '12')
+        scrapers = sites['giantbomb.com'].scrapers
+        self.assertTrue(len(scrapers) == 2, u'Expected 2 scrapers for giantbomb.com, found {0}'.format(len(scrapers)))
+        self.assertIsInstance(scrapers[0], Scraper, u'Expected Scraper object, was {0}'.format(type(scrapers[0])))
 
 if __name__ == "__main__":
     unittest.main()

--- a/resources/tests/test_config_scraper.py
+++ b/resources/tests/test_config_scraper.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyparsing'))
+sys.path.append (os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'lib', 'pyscraper'))
+
+import unittest
+
+from config import Config, Scraper
+import util
+
+class TestScraper(unittest.TestCase):
+    """
+    This unittest class is used for testing the parsing of the Scraper and Site objects from the config_template.xml
+    file. Tests for the parsing process itself is in test_scrapers.py and test_scrapers_artwork.py
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # This is required so that readScraper() can parse the XML instruction files
+        util.RCBHOME = os.path.join(os.path.dirname(__file__), '..', '..')
+
+    def test_ParseValidFileIsSuccessful(self):
+        # Load the default config_template.xml distributed with RCB
+        config_xml_file = os.path.join(os.path.dirname(__file__), '..', 'database', 'config_template.xml')
+        conf = Config(config_xml_file)
+        conf.initXml()
+        #self.assertTrue(conf is None, u'Expected conf to be none')
+
+        sites, msg = conf.readScrapers(conf.tree)
+        self.assertIsInstance(sites, dict, u'Expected list object, was {0}'.format(type(sites)))
+
+        l = len(sites)
+        self.assertTrue(l == 6, u'Expected multiple scraper sites, found {0}'.format(l))
+
+        #self.assertTrue(scrapers['local nfo'].descFilePerGame == 'video')
+        #self.assertTrue(ft.parent == 'game')
+        #self.assertTrue(ft.id == '12')
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/tests/testdata/config_valid.xml
+++ b/resources/tests/testdata/config_valid.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<config version="2.0.8">
+  <RomCollections>
+    <RomCollection id="6" name="NES">
+      <useBuiltinEmulator>False</useBuiltinEmulator>
+      <gameclient />
+      <emulatorCmd>/Path/To/NES/Emulator</emulatorCmd>
+      <emulatorParams>-v -L /Applications/RetroArch.app/Contents/Resources/cores/bnes_libretro.dylib "%rom%"</emulatorParams>
+      <romPath>/Path/To/Roms/GBA/*.zip</romPath>
+      <romPath>/Path/To/Roms/GBA/*.smc</romPath>
+      <saveStatePath />
+      <saveStateParams />
+      <mediaPath type="boxfront">/Path/To/Roms/GBA/Artwork/boxfront/%GAME%.*</mediaPath>
+      <mediaPath type="boxback">/Path/To/Roms/GBA/Artwork/boxback/%GAME%.*</mediaPath>
+      <mediaPath type="cartridge">/Path/To/Roms/GBA/Artwork/cartridge/%GAME%.*</mediaPath>
+      <mediaPath type="screenshot">/Path/To/Roms/GBA/Artwork/screenshot/%GAME%.*</mediaPath>
+      <mediaPath type="fanart">/Path/To/Roms/GBA/Artwork/fanart/%GAME%.*
+      </mediaPath>
+      <preCmd />
+      <postCmd />
+      <useEmuSolo>False</useEmuSolo>
+      <usePopen>False</usePopen>
+      <ignoreOnScan>False</ignoreOnScan>
+      <allowUpdate>True</allowUpdate>
+      <autoplayVideoMain>True</autoplayVideoMain>
+      <autoplayVideoInfo>True</autoplayVideoInfo>
+      <useFoldernameAsGamename>False</useFoldernameAsGamename>
+      <maxFolderDepth>99</maxFolderDepth>
+      <doNotExtractZipFiles>False</doNotExtractZipFiles>
+      <makeLocalCopy>False</makeLocalCopy>
+      <diskPrefix>_Disk.*</diskPrefix>
+      <imagePlacingMain>gameinfobig</imagePlacingMain>
+      <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+      <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+      <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+    </RomCollection>
+    <RomCollection id="7" name="Atari 2600">
+      <useBuiltinEmulator>False</useBuiltinEmulator>
+      <gameclient />
+      <emulatorCmd>/Path/To/Atari2600/Emulator</emulatorCmd>
+      <emulatorParams>"%ROM%"</emulatorParams>
+      <romPath>/Path/To/Roms/Atari2600/*.a26</romPath>
+      <saveStatePath />
+      <saveStateParams />
+      <mediaPath type="boxfront">/Path/To/Roms/Atari2600/Artwork/boxfront/%GAME%.*</mediaPath>
+      <mediaPath type="boxback">/Path/To/Roms/Atari2600/Artwork/boxback/%GAME%.*</mediaPath>
+      <mediaPath type="cartridge">/Path/To/Roms/Atari2600/Artwork/cartridge/%GAME%.*</mediaPath>
+      <mediaPath type="screenshot">/Path/To/Roms/Atari2600/Artwork/screenshot/%GAME%.*</mediaPath>
+      <mediaPath type="fanart">/Path/To/Roms/Atari2600/Artwork/fanart/%GAME%.*</mediaPath>
+      <preCmd />
+      <postCmd />
+      <useEmuSolo>False</useEmuSolo>
+      <usePopen>False</usePopen>
+      <ignoreOnScan>False</ignoreOnScan>
+      <allowUpdate>True</allowUpdate>
+      <autoplayVideoMain>True</autoplayVideoMain>
+      <autoplayVideoInfo>True</autoplayVideoInfo>
+      <useFoldernameAsGamename>False</useFoldernameAsGamename>
+      <maxFolderDepth>99</maxFolderDepth>
+      <doNotExtractZipFiles>False</doNotExtractZipFiles>
+      <makeLocalCopy>False</makeLocalCopy>
+      <diskPrefix>_Disk.*</diskPrefix>
+      <imagePlacingMain>gameinfobig</imagePlacingMain>
+      <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+      <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+      <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+    </RomCollection>
+  </RomCollections>
+  <FileTypes>
+    <FileType id="1" name="boxfront">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="2" name="boxback">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="3" name="cartridge">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="4" name="screenshot">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="5" name="fanart">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="6" name="action">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="7" name="title">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="8" name="3dbox">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="9" name="romcollection">
+      <type>image</type>
+      <parent>romcollection</parent>
+    </FileType>
+    <FileType id="10" name="developer">
+      <type>image</type>
+      <parent>developer</parent>
+    </FileType>
+    <FileType id="11" name="publisher">
+      <type>image</type>
+      <parent>publisher</parent>
+    </FileType>
+    <FileType id="12" name="gameplay">
+      <type>video</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="13" name="cabinet">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+    <FileType id="14" name="marquee">
+      <type>image</type>
+      <parent>game</parent>
+    </FileType>
+  </FileTypes>
+  <ImagePlacing>
+    <fileTypeFor name="gameinfobig">
+      <fileTypeForGameList>boxfront</fileTypeForGameList>
+      <fileTypeForGameList>screenshot</fileTypeForGameList>
+      <fileTypeForGameList>title</fileTypeForGameList>
+      <fileTypeForGameList>action</fileTypeForGameList>
+      <fileTypeForGameListSelected>boxfront</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>screenshot</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>title</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>action</fileTypeForGameListSelected>
+      <fileTypeForMainViewBackground>fanart</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>boxfront</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>screenshot</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>title</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>action</fileTypeForMainViewBackground>
+      <fileTypeForMainViewGameInfoBig>screenshot</fileTypeForMainViewGameInfoBig>
+      <fileTypeForMainViewGameInfoBig>boxfront</fileTypeForMainViewGameInfoBig>
+      <fileTypeForMainViewGameInfoBig>action</fileTypeForMainViewGameInfoBig>
+      <fileTypeForMainViewGameInfoBig>title</fileTypeForMainViewGameInfoBig>
+      <fileTypeForMainView1>publisher</fileTypeForMainView1>
+      <fileTypeForMainView2>romcollection</fileTypeForMainView2>
+      <fileTypeForMainView3>developer</fileTypeForMainView3>
+    </fileTypeFor>
+    <fileTypeFor name="gameinfosmall">
+      <fileTypeForGameList>boxfront</fileTypeForGameList>
+      <fileTypeForGameList>screenshot</fileTypeForGameList>
+      <fileTypeForGameList>title</fileTypeForGameList>
+      <fileTypeForGameList>action</fileTypeForGameList>
+      <fileTypeForGameListSelected>boxfront</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>screenshot</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>title</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>action</fileTypeForGameListSelected>
+      <fileTypeForMainViewBackground>fanart</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>boxfront</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>screenshot</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>title</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>action</fileTypeForMainViewBackground>
+      <fileTypeForMainViewGameInfoUpperLeft>screenshot</fileTypeForMainViewGameInfoUpperLeft>
+      <fileTypeForMainViewGameInfoUpperLeft>action</fileTypeForMainViewGameInfoUpperLeft>
+      <fileTypeForMainViewGameInfoUpperLeft>title</fileTypeForMainViewGameInfoUpperLeft>
+      <fileTypeForMainViewGameInfoUpperRight>boxfront</fileTypeForMainViewGameInfoUpperRight>
+      <fileTypeForMainViewGameInfoLowerLeft>cartridge</fileTypeForMainViewGameInfoLowerLeft>
+      <fileTypeForMainViewGameInfoLowerRight>boxback</fileTypeForMainViewGameInfoLowerRight>
+      <fileTypeForMainViewGameInfoLowerRight>title</fileTypeForMainViewGameInfoLowerRight>
+      <fileTypeForMainView1>publisher</fileTypeForMainView1>
+      <fileTypeForMainView2>romcollection</fileTypeForMainView2>
+      <fileTypeForMainView3>developer</fileTypeForMainView3>
+    </fileTypeFor>
+    <fileTypeFor name="gameinfomamemarquee">
+      <fileTypeForGameList>marquee</fileTypeForGameList>
+      <fileTypeForGameList>boxfront</fileTypeForGameList>
+      <fileTypeForGameList>title</fileTypeForGameList>
+      <fileTypeForGameListSelected>marquee</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>boxfront</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>title</fileTypeForGameListSelected>
+      <fileTypeForMainViewBackground>boxfront</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>title</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>action</fileTypeForMainViewBackground>
+      <fileTypeForMainViewGameInfoLeft>cabinet</fileTypeForMainViewGameInfoLeft>
+      <fileTypeForMainViewGameInfoUpperRight>title</fileTypeForMainViewGameInfoUpperRight>
+      <fileTypeForMainViewGameInfoLowerRight>action</fileTypeForMainViewGameInfoLowerRight>
+      <fileTypeForMainView1>publisher</fileTypeForMainView1>
+      <fileTypeForMainView2>romcollection</fileTypeForMainView2>
+      <fileTypeForMainView3>developer</fileTypeForMainView3>
+    </fileTypeFor>
+    <fileTypeFor name="gameinfomamecabinet">
+      <fileTypeForGameList>cabinet</fileTypeForGameList>
+      <fileTypeForGameList>boxfront</fileTypeForGameList>
+      <fileTypeForGameList>title</fileTypeForGameList>
+      <fileTypeForGameListSelected>cabinet</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>boxfront</fileTypeForGameListSelected>
+      <fileTypeForGameListSelected>title</fileTypeForGameListSelected>
+      <fileTypeForMainViewBackground>boxfront</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>title</fileTypeForMainViewBackground>
+      <fileTypeForMainViewBackground>action</fileTypeForMainViewBackground>
+      <fileTypeForMainViewGameInfoUpperLeft>title</fileTypeForMainViewGameInfoUpperLeft>
+      <fileTypeForMainViewGameInfoUpperRight>action</fileTypeForMainViewGameInfoUpperRight>
+      <fileTypeForMainViewGameInfoLower>marquee</fileTypeForMainViewGameInfoLower>
+      <fileTypeForMainView1>publisher</fileTypeForMainView1>
+      <fileTypeForMainView2>romcollection</fileTypeForMainView2>
+      <fileTypeForMainView3>developer</fileTypeForMainView3>
+    </fileTypeFor>
+  </ImagePlacing>
+  <Scrapers>
+    <Site name="local nfo" descFilePerGame="True" searchGameByCRC="False">
+      <Scraper parseInstruction="00 - local nfo.xml" source="nfo" />
+    </Site>
+    <Site name="thegamesdb.net" descFilePerGame="True" searchGameByCRC="False">
+      <Scraper parseInstruction="02 - thegamesdb.xml" source="http://thegamesdb.net/api/GetGame.php?name=%GAME%&amp;platform=%PLATFORM%" />
+    </Site>
+    <Site name="giantbomb.com" descFilePerGame="True" searchGameByCRC="False">
+      <Scraper parseInstruction="03.01 - giantbomb - search.xml" returnUrl="true" source="http://api.giantbomb.com/search/?api_key=%GIANTBOMBAPIKey%&amp;query=%GAME%&amp;resources=game&amp;field_list=api_detail_url,name&amp;format=xml" />
+      <Scraper parseInstruction="03.02 - giantbomb - detail.xml" source="1" />
+    </Site>
+    <Site descFilePerGame="True" name="mobygames.com" searchGameByCRC="False">
+      <Scraper parseInstruction="04.01 - mobygames - gamesearch.xml" returnUrl="true" source="http://www.mobygames.com/search/quick?game=%GAME%&amp;amp;p=%PLATFORM%" />
+      <Scraper parseInstruction="04.02 - mobygames - details.xml" source="1" />
+      <Scraper parseInstruction="04.03 - mobygames - coverlink front.xml" returnUrl="true" source="1" sourceAppend="cover-art" />
+      <Scraper parseInstruction="04.04 - mobygames - coverdetail front.xml" source="2" />
+      <Scraper parseInstruction="04.05 - mobygames - coverlink back.xml" returnUrl="true" source="1" sourceAppend="cover-art" />
+      <Scraper parseInstruction="04.06 - mobygames - coverdetail back.xml" source="3" />
+      <Scraper parseInstruction="04.07 - mobygames - coverlink media.xml" returnUrl="true" source="1" sourceAppend="cover-art" />
+      <Scraper parseInstruction="04.08 - mobygames - coverdetail media.xml" source="4" />
+      <Scraper parseInstruction="04.09 - mobygames - screenshotlink.xml" returnUrl="true" source="1" sourceAppend="screenshots" />
+      <Scraper parseInstruction="04.10 - mobygames - screenshot detail.xml" source="5" />
+    </Site>
+    <Site descFilePerGame="True" name="archive.vg" searchGameByCRC="False">
+      <Scraper encoding="iso-8859-1" parseInstruction="05.01 - archive - search.xml" returnUrl="true" source="http://api.archive.vg/2.0/Archive.search/%ARCHIVEAPIKEY%/%GAME%" />
+      <Scraper encoding="iso-8859-1" parseInstruction="05.02 - archive - detail.xml" source="1" />
+    </Site>
+    <Site name="maws.mameworld.info" descFilePerGame="True" searchGameByCRC="False">
+      <Scraper parseInstruction="06 - maws.xml" source="http://maws.mameworld.info/maws/romset/%GAME%" encoding='iso-8859-1'/>
+    </Site>
+  </Scrapers>
+</config>

--- a/resources/tests/testdata/romcollections_invalid_missingattribs.xml
+++ b/resources/tests/testdata/romcollections_invalid_missingattribs.xml
@@ -1,0 +1,147 @@
+<config version="2.0.8">
+    <!-- All paths are fake, we don't currently validate on path -->
+    <RomCollections>
+        <!-- RomCollection missing name attrib, otherwise OK -->
+        <RomCollection id="6">
+            <useBuiltinEmulator>False</useBuiltinEmulator>
+            <gameclient />
+            <emulatorCmd>/Path/To/NES/Emulator</emulatorCmd>
+            <emulatorParams>-v -L /Applications/RetroArch.app/Contents/Resources/cores/bnes_libretro.dylib "%rom%"</emulatorParams>
+            <romPath>/Path/To/Roms/GBA/*.zip</romPath>
+            <romPath>/Path/To/Roms/GBA/*.smc</romPath>
+            <saveStatePath />
+            <saveStateParams />
+            <mediaPath type="boxfront">/Path/To/Roms/GBA/Artwork/boxfront/%GAME%.*</mediaPath>
+            <mediaPath type="boxback">/Path/To/Roms/GBA/Artwork/boxback/%GAME%.*</mediaPath>
+            <mediaPath type="cartridge">/Path/To/Roms/GBA/Artwork/cartridge/%GAME%.*</mediaPath>
+            <mediaPath type="screenshot">/Path/To/Roms/GBA/Artwork/screenshot/%GAME%.*</mediaPath>
+            <mediaPath type="fanart">/Path/To/Roms/GBA/Artwork/fanart/%GAME%.*
+            </mediaPath>
+            <preCmd />
+            <postCmd />
+            <useEmuSolo>False</useEmuSolo>
+            <usePopen>False</usePopen>
+            <ignoreOnScan>False</ignoreOnScan>
+            <allowUpdate>True</allowUpdate>
+            <autoplayVideoMain>True</autoplayVideoMain>
+            <autoplayVideoInfo>True</autoplayVideoInfo>
+            <useFoldernameAsGamename>False</useFoldernameAsGamename>
+            <maxFolderDepth>99</maxFolderDepth>
+            <doNotExtractZipFiles>False</doNotExtractZipFiles>
+            <makeLocalCopy>False</makeLocalCopy>
+            <diskPrefix>_Disk.*</diskPrefix>
+            <imagePlacingMain>gameinfobig</imagePlacingMain>
+            <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+            <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+            <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+        </RomCollection>
+         <!-- RomCollection missing id attrib, otherwise OK -->
+        <RomCollection name="Atari 2600">
+            <useBuiltinEmulator>False</useBuiltinEmulator>
+            <gameclient />
+            <emulatorCmd>/Path/To/Atari2600/Emulator</emulatorCmd>
+            <emulatorParams>"%ROM%"</emulatorParams>
+            <romPath>/Path/To/Roms/Atari2600/*.a26</romPath>
+            <saveStatePath />
+            <saveStateParams />
+            <mediaPath type="boxfront">/Path/To/Roms/Atari2600/Artwork/boxfront/%GAME%.*</mediaPath>
+            <mediaPath type="boxback">/Path/To/Roms/Atari2600/Artwork/boxback/%GAME%.*</mediaPath>
+            <mediaPath type="cartridge">/Path/To/Roms/Atari2600/Artwork/cartridge/%GAME%.*</mediaPath>
+            <mediaPath type="screenshot">/Path/To/Roms/Atari2600/Artwork/screenshot/%GAME%.*</mediaPath>
+            <mediaPath type="fanart">/Path/To/Roms/Atari2600/Artwork/fanart/%GAME%.*</mediaPath>
+            <preCmd />
+            <postCmd />
+            <useEmuSolo>False</useEmuSolo>
+            <usePopen>False</usePopen>
+            <ignoreOnScan>False</ignoreOnScan>
+            <allowUpdate>True</allowUpdate>
+            <autoplayVideoMain>True</autoplayVideoMain>
+            <autoplayVideoInfo>True</autoplayVideoInfo>
+            <useFoldernameAsGamename>False</useFoldernameAsGamename>
+            <maxFolderDepth>99</maxFolderDepth>
+            <doNotExtractZipFiles>False</doNotExtractZipFiles>
+            <makeLocalCopy>False</makeLocalCopy>
+            <diskPrefix>_Disk.*</diskPrefix>
+            <imagePlacingMain>gameinfobig</imagePlacingMain>
+            <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+            <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+            <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+        </RomCollection>
+         <!-- RomCollection OK -->
+        <RomCollection id="3" name="SNES">
+            <useBuiltinEmulator>False</useBuiltinEmulator>
+            <gameclient />
+            <emulatorCmd>/Path/To/SNES/Emulator</emulatorCmd>
+            <emulatorParams>"%ROM%"</emulatorParams>
+            <romPath>/Path/To/Roms/SNES/*.smc</romPath>
+            <saveStatePath />
+            <saveStateParams />
+            <mediaPath type="boxfront">/Path/To/Roms/SNES/Artwork/boxfront/%GAME%.*</mediaPath>
+            <mediaPath type="boxback">/Path/To/Roms/SNES/Artwork/boxback/%GAME%.*</mediaPath>
+            <mediaPath type="cartridge">/Path/To/Roms/SNES/Artwork/cartridge/%GAME%.*</mediaPath>
+            <mediaPath type="screenshot">/Path/To/Roms/SNES/Artwork/screenshot/%GAME%.*</mediaPath>
+            <mediaPath type="fanart">/Path/To/Roms/SNES/Artwork/fanart/%GAME%.*</mediaPath>
+            <preCmd />
+            <postCmd />
+            <useEmuSolo>False</useEmuSolo>
+            <usePopen>False</usePopen>
+            <ignoreOnScan>False</ignoreOnScan>
+            <allowUpdate>True</allowUpdate>
+            <autoplayVideoMain>True</autoplayVideoMain>
+            <autoplayVideoInfo>True</autoplayVideoInfo>
+            <useFoldernameAsGamename>False</useFoldernameAsGamename>
+            <maxFolderDepth>99</maxFolderDepth>
+            <doNotExtractZipFiles>False</doNotExtractZipFiles>
+            <makeLocalCopy>False</makeLocalCopy>
+            <diskPrefix>_Disk.*</diskPrefix>
+            <imagePlacingMain>gameinfobig</imagePlacingMain>
+            <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+            <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+            <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+        </RomCollection>
+    </RomCollections>
+
+    <!-- The following are explicitly referenced in the RomCollections above and need to be specified -->
+
+    <ImagePlacing>
+        <fileTypeFor name="gameinfobig">
+
+        </fileTypeFor>
+        <fileTypeFor name="gameinfosmall">
+
+        </fileTypeFor>
+    </ImagePlacing>
+
+    <FileTypes>
+        <FileType id="1" name="boxfront">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="2" name="boxback">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="3" name="cartridge">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="4" name="screenshot">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="5" name="fanart">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+    </FileTypes>
+
+    <Scrapers>
+        <Site descFilePerGame="True" name="thegamesdb.net" searchGameByCRC="False">
+            <Scraper parseInstruction="02 - thegamesdb.xml" source="http://thegamesdb.net/api/GetGame.php?name=%GAME%&amp;platform=%PLATFORM%" />
+        </Site>
+        <Site descFilePerGame="True" name="archive.vg" searchGameByCRC="False">
+            <Scraper encoding="iso-8859-1" parseInstruction="05.01 - archive - search.xml" returnUrl="true" source="http://api.archive.vg/2.0/Archive.search/%ARCHIVEAPIKEY%/%GAME%" />
+            <Scraper encoding="iso-8859-1" parseInstruction="05.02 - archive - detail.xml" source="1" />
+        </Site>
+    </Scrapers>
+</config>

--- a/resources/tests/testdata/romcollections_two_valid.xml
+++ b/resources/tests/testdata/romcollections_two_valid.xml
@@ -1,0 +1,112 @@
+<config version="2.0.8">
+    <!-- All paths are fake, we don't currently validate on path -->
+    <RomCollections>
+        <RomCollection id="6" name="NES">
+            <useBuiltinEmulator>False</useBuiltinEmulator>
+            <gameclient />
+            <emulatorCmd>/Path/To/NES/Emulator</emulatorCmd>
+            <emulatorParams>-v -L /Applications/RetroArch.app/Contents/Resources/cores/bnes_libretro.dylib "%rom%"</emulatorParams>
+            <romPath>/Path/To/Roms/GBA/*.zip</romPath>
+            <romPath>/Path/To/Roms/GBA/*.smc</romPath>
+            <saveStatePath />
+            <saveStateParams />
+            <mediaPath type="boxfront">/Path/To/Roms/GBA/Artwork/boxfront/%GAME%.*</mediaPath>
+            <mediaPath type="boxback">/Path/To/Roms/GBA/Artwork/boxback/%GAME%.*</mediaPath>
+            <mediaPath type="cartridge">/Path/To/Roms/GBA/Artwork/cartridge/%GAME%.*</mediaPath>
+            <mediaPath type="screenshot">/Path/To/Roms/GBA/Artwork/screenshot/%GAME%.*</mediaPath>
+            <mediaPath type="fanart">/Path/To/Roms/GBA/Artwork/fanart/%GAME%.*
+            </mediaPath>
+            <preCmd />
+            <postCmd />
+            <useEmuSolo>False</useEmuSolo>
+            <usePopen>False</usePopen>
+            <ignoreOnScan>False</ignoreOnScan>
+            <allowUpdate>True</allowUpdate>
+            <autoplayVideoMain>True</autoplayVideoMain>
+            <autoplayVideoInfo>True</autoplayVideoInfo>
+            <useFoldernameAsGamename>False</useFoldernameAsGamename>
+            <maxFolderDepth>99</maxFolderDepth>
+            <doNotExtractZipFiles>False</doNotExtractZipFiles>
+            <makeLocalCopy>False</makeLocalCopy>
+            <diskPrefix>_Disk.*</diskPrefix>
+            <imagePlacingMain>gameinfobig</imagePlacingMain>
+            <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+            <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+            <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+        </RomCollection>
+        <RomCollection id="7" name="Atari 2600">
+            <useBuiltinEmulator>False</useBuiltinEmulator>
+            <gameclient />
+            <emulatorCmd>/Path/To/Atari2600/Emulator</emulatorCmd>
+            <emulatorParams>"%ROM%"</emulatorParams>
+            <romPath>/Path/To/Roms/Atari2600/*.a26</romPath>
+            <saveStatePath />
+            <saveStateParams />
+            <mediaPath type="boxfront">/Path/To/Roms/Atari2600/Artwork/boxfront/%GAME%.*</mediaPath>
+            <mediaPath type="boxback">/Path/To/Roms/Atari2600/Artwork/boxback/%GAME%.*</mediaPath>
+            <mediaPath type="cartridge">/Path/To/Roms/Atari2600/Artwork/cartridge/%GAME%.*</mediaPath>
+            <mediaPath type="screenshot">/Path/To/Roms/Atari2600/Artwork/screenshot/%GAME%.*</mediaPath>
+            <mediaPath type="fanart">/Path/To/Roms/Atari2600/Artwork/fanart/%GAME%.*</mediaPath>
+            <preCmd />
+            <postCmd />
+            <useEmuSolo>False</useEmuSolo>
+            <usePopen>False</usePopen>
+            <ignoreOnScan>False</ignoreOnScan>
+            <allowUpdate>True</allowUpdate>
+            <autoplayVideoMain>True</autoplayVideoMain>
+            <autoplayVideoInfo>True</autoplayVideoInfo>
+            <useFoldernameAsGamename>False</useFoldernameAsGamename>
+            <maxFolderDepth>99</maxFolderDepth>
+            <doNotExtractZipFiles>False</doNotExtractZipFiles>
+            <makeLocalCopy>False</makeLocalCopy>
+            <diskPrefix>_Disk.*</diskPrefix>
+            <imagePlacingMain>gameinfobig</imagePlacingMain>
+            <imagePlacingInfo>gameinfosmall</imagePlacingInfo>
+            <scraper name="thegamesdb.net" replaceKeyString="" replaceValueString="" />
+            <scraper name="archive.vg" replaceKeyString="" replaceValueString="" />
+        </RomCollection>
+    </RomCollections>
+
+    <!-- The following are explicitly referenced in the RomCollections above and need to be specified -->
+    <ImagePlacing>
+        <fileTypeFor name="gameinfobig">
+
+        </fileTypeFor>
+        <fileTypeFor name="gameinfosmall">
+
+        </fileTypeFor>
+    </ImagePlacing>
+
+    <FileTypes>
+        <FileType id="1" name="boxfront">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="2" name="boxback">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="3" name="cartridge">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="4" name="screenshot">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+        <FileType id="5" name="fanart">
+            <type>image</type>
+            <parent>game</parent>
+        </FileType>
+    </FileTypes>
+
+    <Scrapers>
+        <Site descFilePerGame="True" name="thegamesdb.net" searchGameByCRC="False">
+            <Scraper parseInstruction="02 - thegamesdb.xml" source="http://thegamesdb.net/api/GetGame.php?name=%GAME%&amp;platform=%PLATFORM%" />
+        </Site>
+        <Site descFilePerGame="True" name="archive.vg" searchGameByCRC="False">
+            <Scraper encoding="iso-8859-1" parseInstruction="05.01 - archive - search.xml" returnUrl="true" source="http://api.archive.vg/2.0/Archive.search/%ARCHIVEAPIKEY%/%GAME%" />
+            <Scraper encoding="iso-8859-1" parseInstruction="05.02 - archive - detail.xml" source="1" />
+        </Site>
+    </Scrapers>
+</config>


### PR DESCRIPTION
Allow classes in config.py to inherit from object. This means we can use attr methods to reduce the amount of attribute setting and getting when reading from the XML. Also modify code to adhere to PEP8 standards for whitespace, punctuation, etc.

Added test cases for the classes as appropriate.
