### PR TITLE
New launch method for zip archives.

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -257,6 +257,7 @@
 	<string id="52037">Use RetroPlayer</string>
 	<string id="52038">Gameclient</string>
 	<string id="52039">Make Local Copy</string>
+	<string id="52040">Progressive Zip Extraction</string>
 	
 	<string id="52034">Save Config</string>
 	<string id="52035">Cancel</string>
@@ -461,7 +462,8 @@
 	<string id="32201">Path to emu_autoconfig.xml</string>
 	<string id="32202">%s (Installed)</string>
 	<string id="32203">Available autoconfig emulators</string>
-	
+	<string id="32204">Extracting file %d of %d...</string>
+	<string id="32205">Copied %.1f MB of %.1f MB</string>
 	
 	<!-- Settings -->
 	<string id="32300">General</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -461,7 +461,8 @@
 	<string id="32201">Pfad zu emu_autoconfig.xml</string>
 	<string id="32202">%s (Installiert)</string>
 	<string id="32203">Per autoconfig verfügbare Emulatoren</string>
-
+	<string id="32204">Entpacke Datei %d von %d...</string>
+	<string id="32205">Bereits %.1f MB von %.1f MB kopiert</string>
 	
 	<!-- Settings -->
 	<string id="32300">Allgemein</string>

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -317,7 +317,13 @@ class RomCollection(object):
 	doNotExtractZipFiles: If the rom is a zip file, extract it to a temporary local directory. Used in
 	    cases of unsupported zip files (usually .7z)
 	makeLocalCopy: Whether to copy the rom to a temporary local directory and use that in the launch. Used
-	    primarily to workaround SMB issues
+	    primarily to work around SMB issues
+	progressiveZipExtraction: Process zip files more effectively. Instead of transfering the whole zip
+	    file, first load just the file list. Then - after selecting the desired files from the list - extract
+	    only the compressed files locally and unzip those. Saves on transfering the whole zip file from slow 
+	    storage like SD cards or network shares before anything else is handled. Instead it shows the file
+	    list almost instantly and transfers only the parts of the zip file that are required to extract the
+	    desired compressed files. Hugh advantage on large merged romsets. 
 	diskPrefix: String used to assist in identifying whether a romset has multiple files (representing a
 	    multi-disk game).
 	"""
@@ -348,6 +354,7 @@ class RomCollection(object):
 		self.useFoldernameAsGamename = False
 		self.doNotExtractZipFiles = False
 		self.makeLocalCopy = False
+		self.progressiveZipExtraction = False
 		self.diskPrefix = '_Disk.*'
 
 		# These are used for XBox, which is now legacy and no longer supported by Kodi
@@ -642,7 +649,7 @@ class Config(object):
 			# RomCollection bool properties
 			for var in ['useBuiltinEmulator', 'ignoreOnScan', 'allowUpdate', 'useEmuSolo', 'usePopen',
 						'autoplayVideoMain', 'autoplayVideoInfo', 'useFoldernameAsGamename',
-						'doNotExtractZipFiles', 'makeLocalCopy', 'xboxCreateShortcut',
+						'doNotExtractZipFiles', 'makeLocalCopy', 'progressiveZipExtraction', 'xboxCreateShortcut',
 						'xboxCreateShortcutAddRomfile', 'xboxCreateShortcutUseShortGamename']:
 				romCollection.__setattr__(var, romCollectionRow.findtext(var, '').upper() == 'TRUE')
 

--- a/resources/lib/configxmlwriter.py
+++ b/resources/lib/configxmlwriter.py
@@ -75,6 +75,7 @@ class ConfigXmlWriter:
 			SubElement(romCollectionXml, 'maxFolderDepth').text = str(romCollection.maxFolderDepth)
 			SubElement(romCollectionXml, 'doNotExtractZipFiles').text = str(romCollection.doNotExtractZipFiles)
 			SubElement(romCollectionXml, 'makeLocalCopy').text = str(romCollection.makeLocalCopy)
+			SubElement(romCollectionXml, 'progressiveZipExtraction').text = str(romCollection.progressiveZipExtraction)
 			SubElement(romCollectionXml, 'diskPrefix').text = str(romCollection.diskPrefix)
 			
 			if (os.environ.get( "OS", "xbox" ) == "xbox"):

--- a/resources/lib/dialogeditromcollection.py
+++ b/resources/lib/dialogeditromcollection.py
@@ -60,7 +60,7 @@ CONTROL_BUTTON_SAVESTATEPARAMS = 5480
 CONTROL_BUTTON_PRECMD = 5510
 CONTROL_BUTTON_POSTCMD = 5520
 CONTROL_BUTTON_MAKELOCALCOPY = 5560
-
+CONTROL_BUTTON_PROGRESSIVEZIPEXTRACTION = 5570
 
 class EditRomCollectionDialog(dialogbase.DialogBaseEdit):
 		
@@ -81,6 +81,7 @@ class EditRomCollectionDialog(dialogbase.DialogBaseEdit):
 		{'control': CONTROL_BUTTON_USEPOPEN, 'value': 'usePopen'},
 		{'control': CONTROL_BUTTON_DONTEXTRACTZIP, 'value': 'doNotExtractZipFiles'},
 		{'control': CONTROL_BUTTON_MAKELOCALCOPY, 'value': 'makeLocalCopy'},
+		{'control': CONTROL_BUTTON_PROGRESSIVEZIPEXTRACTION, 'value': 'progressiveZipExtraction'},
 	]
 
 	# Mapping between widget ID and RomCollection attribute - labels

--- a/resources/skins/Default/720p/script-RCB-editromcollection.xml
+++ b/resources/skins/Default/720p/script-RCB-editromcollection.xml
@@ -2177,7 +2177,26 @@
 					<onleft>7000</onleft>
 					<onright>6000</onright>
 					<onup>5450</onup>
-					<ondown>5540</ondown>
+					<ondown>5570</ondown>
+				</control>
+				<!-- Make local copy -->
+				<control type="radiobutton" id="5570">
+					<posx>0</posx>
+					<posy>330</posy>
+					<width>660</width>
+					<height>30</height>
+					<radiowidth>24</radiowidth>
+					<radioheight>24</radioheight>
+					<font>font13</font>
+					<label>$ADDON[script.games.rom.collection.browser 52040]</label>
+					<textcolor>88FFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<texturefocus>rcb-MenuItemFO.png</texturefocus>
+					<texturenofocus>rcb-MenuItemNF.png</texturenofocus>
+					<onleft>7000</onleft>
+					<onright>6000</onright>
+					<onup>5460</onup>
+					<ondown>5550</ondown>
 				</control>
 				
 				<!-- Use RetroPlayer -->


### PR DESCRIPTION
"progressiveZipExtraction (PZE)" extracts only the file list at first and extracts only the selected files afterwards.
Might replace "makeLocalCopy". Much faster and less data transmitted especially on merged romset archives. For zip only; not 7z.

It works nicely on Linux. It is meant for low storage devices that will pull their files from slow storage; such as a Fire TV accessing merged archives on an SMB-share. Getting the list of files in archive is lighting fast with PZE. When extracting a progress dialog displays extraction progress.

Behind the scenes it works like this: only the required parts of the zip are downloaded to temporary local storage and repaired to appear like a zip containing just that one (or more if requested) file. Python's zipfile will then process the local temporary archive.

It's basically "makeLocalCopy 2.0". But only for zip files. 7z would not profit from this approach. makelocalCopy is still the best choice for 7z archives.