### PR TITLE
Remove Import Dialog option to change scraping mode for this import

### DIFF
--- a/resources/lib/dialogimportoptions.py
+++ b/resources/lib/dialogimportoptions.py
@@ -16,7 +16,6 @@ CONTROL_BUTTON_OK = 5300
 CONTROL_BUTTON_CANCEL = 5310
 
 CONTROL_LIST_ROMCOLLECTIONS = 5210
-CONTROL_LIST_SCRAPEMODE = 5220
 CONTROL_LIST_FUZZYFACTOR = 5260
 CONTROL_LIST_SCRAPER1 = 5270
 CONTROL_LIST_SCRAPER2 = 5280
@@ -54,9 +53,6 @@ class ImportOptionsDialog(xbmcgui.WindowXMLDialog):
 			self.setFocus(self.getControl(CONTROL_BUTTON_SCRAPEMODE_UP))
 		else:
 			xbmc.executebuiltin('Skin.Reset(%s)' % util.SETTING_RCB_IMPORTOPTIONS_DISABLEROMCOLLECTIONS)
-		
-		# Scraping modes
-		self.addItemsToList(CONTROL_LIST_SCRAPEMODE, ['Automatic: Accurate', 'Automatic: Guess Matches', 'Interactive: Select Matches'])
 
 		sitesInList = self.getAvailableScrapers()
 
@@ -170,16 +166,10 @@ class ImportOptionsDialog(xbmcgui.WindowXMLDialog):
 				break
 			
 	def doImport(self):
-		# Get selected Scraping mode
-		control = self.getControlById(CONTROL_LIST_SCRAPEMODE)
-		scrapingMode = control.getSelectedPosition()
-		
-		log.debug('Selected scraping mode: {0}'.format(scrapingMode))
-		
 		romCollections, statusOk = self.setScrapersInConfig()
-		
+
 		if statusOk:
-			self.gui.doImport(scrapingMode, romCollections, self.isRescrape)
+			self.gui.doImport(romCollections, self.isRescrape)
 		
 	def setScrapersInConfig(self):
 		# Read selected Rom Collection

--- a/resources/skins/Default/720p/script-RCB-importoptions.xml
+++ b/resources/skins/Default/720p/script-RCB-importoptions.xml
@@ -214,150 +214,11 @@
 				<onleft>5211</onleft>
 				<onright>5300</onright>
 				<onup>5101</onup>
-				<ondown>5223</ondown>
+				<ondown>5330</ondown>
 				<enable>!Skin.HasSetting(rcb_disableRomcollections)</enable>
 			</control>
 			
-			<!-- Scraping mode -->		
-			<control type="list" id="5220">
-				<hitrect x="0" y="0" w="0" h="0" />
-				<posx>40</posx>
-				<posy>65</posy>
-				<width>630</width>
-				<height>30</height>
-				<onleft>5220</onleft>
-				<onright>5220</onright>
-				<onup>5220</onup>
-				<ondown>5220</ondown>
-				<pagecontrol>-</pagecontrol>
-				<scrolltime>0</scrolltime>
-				<itemlayout height="1" width="750">
-				</itemlayout>
-				<focusedlayout height="30" width="630">
-					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
-						<width>630</width>
-						<height>30</height>
-						<texture>rcb-MenuItemNF.png</texture>
-						<visible>![Control.HasFocus(5222) | Control.HasFocus(5223)]</visible>
-					</control>
-					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
-						<width>630</width>
-						<height>30</height>
-						<texture>rcb-MenuItemFO.png</texture>
-						<visible>[Control.HasFocus(5222) | Control.HasFocus(5223)]</visible>
-					</control>
-					<control type="label">
-						<posx>7</posx>
-						<posy>5</posy>
-						<width>200</width>
-						<height>20</height>
-						<font>font13</font>
-						<textcolor>88FFFFFF</textcolor>
-						<align>left</align>
-						<aligny>center</aligny>
-						<label>$ADDON[script.games.rom.collection.browser 32801]</label>
-						<visible>![Control.HasFocus(5222) | Control.HasFocus(5223)]</visible>
-					</control>
-					<control type="label">
-						<posx>7</posx>
-						<posy>5</posy>
-						<width>200</width>
-						<height>20</height>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-						<align>left</align>
-						<aligny>center</aligny>
-						<label>$ADDON[script.games.rom.collection.browser 32801]</label>
-						<visible>[Control.HasFocus(5222) | Control.HasFocus(5223)]</visible>
-					</control>
-					<control type="label">
-						<posx>570</posx>
-						<posy>5</posy>
-						<width>330</width>
-						<height>20</height>
-						<font>font13</font>
-						<textcolor>88FFFFFF</textcolor>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
-						<visible>![Control.HasFocus(5222) | Control.HasFocus(5223)] + Skin.HasSetting(rcb_useOldAlignment)</visible>
-					</control>
-					<control type="label">
-						<posx>230</posx>
-						<posy>5</posy>
-						<width>330</width>
-						<height>20</height>
-						<font>font13</font>
-						<textcolor>88FFFFFF</textcolor>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
-						<visible>![Control.HasFocus(5222) | Control.HasFocus(5223)] + !Skin.HasSetting(rcb_useOldAlignment)</visible>
-					</control>
-					
-					<control type="label">
-						<posx>570</posx>
-						<posy>5</posy>
-						<width>330</width>
-						<height>20</height>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
-						<visible>[Control.HasFocus(5222) | Control.HasFocus(5223)] + Skin.HasSetting(rcb_useOldAlignment)</visible>
-					</control>
-					<control type="label">
-						<posx>230</posx>
-						<posy>5</posy>
-						<width>330</width>
-						<height>20</height>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
-						<visible>[Control.HasFocus(5222) | Control.HasFocus(5223)] + !Skin.HasSetting(rcb_useOldAlignment)</visible>
-					</control>
-				</focusedlayout>
-			</control>
-			<control type="button" id="5222">
-				<description>Menu Item Next Button</description>
-				<posx>630</posx>
-				<posy>70</posy>
-				<width>20</width>
-				<height>20</height>
-				<label>-</label>
-				<font>-</font>
-				<texturenofocus>rcb-scroll-down-2.png</texturenofocus>
-				<texturefocus>rcb-scroll-down-focus-2.png</texturefocus>
-				<onclick>Control.Move(5220,1)</onclick>
-				<onleft>5300</onleft>
-				<onright>5223</onright>
-				<onup>5211</onup>
-				<ondown>5330</ondown>
-			</control>
-			<control type="button" id="5223">
-				<description>Menu Item Prev Button</description>
-				<posx>650</posx>
-				<posy>70</posy>
-				<width>20</width>
-				<height>20</height>
-				<label>-</label>
-				<font>-</font>
-				<texturenofocus>rcb-scroll-up-2.png</texturenofocus>
-				<texturefocus>rcb-scroll-up-focus-2.png</texturefocus>
-				<onclick>Control.Move(5220,-1)</onclick>
-				<onleft>5222</onleft>
-				<onright>5300</onright>
-				<onup>5212</onup>
-				<ondown>5330</ondown>
-			</control>
-			
+			<!-- Change Scrapers for this Run -->
 			<control type="radiobutton" id="5330">
 				<posx>40</posx>
 				<posy>110</posy>
@@ -373,7 +234,7 @@
 				<texturenofocus>rcb-MenuItemNF.png</texturenofocus>
 				<onleft>5300</onleft>
 				<onright>5300</onright>
-				<onup>5223</onup>
+				<onup>5212</onup>
 				<ondown>5272</ondown>
 				<onclick>Skin.ToggleSetting(rcb_overwriteImportOptions)</onclick>
 			</control>


### PR DESCRIPTION
Fixes exception calling import function

The option can be changed in the addon settings dialog, and we want to eventually deprecate the entire dialog and make the import process ask less questions of the user