### PR TITLE
Refactor scraping remove multigame support

### DIFF
--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -342,9 +342,6 @@ class Site(object):
 	def __repr__(self):
 		return "<Site: %s>" % self.__dict__
 
-	def is_multigame_scraper(self):
-		return not self.descFilePerGame
-
 	def is_localartwork_scraper(self):
 		return self.name == util.localize(32153)
 

--- a/resources/lib/dbupdate.py
+++ b/resources/lib/dbupdate.py
@@ -1,7 +1,5 @@
 
-import os, sys
 import getpass, glob
-import zipfile
 import time
 import urllib2
 import io
@@ -258,8 +256,7 @@ class DBUpdate(object):
 					# Abort the scraping entirely
 					break
 				except Exception as exc:
-					log.warn("an error occured while adding game {0}".format(gamenameFromFile))
-					log.warn("Error: {0}".format(exc))
+					log.warn(u"An error occurred while adding game {0}: {1}".format(gamenameFromFile, exc))
 					self.missingDescFile.add_entry(gamenameFromFile)
 
 					continue


### PR DESCRIPTION
Remove references to multigame scrapers when scraping. None of the existing XML scrapers really supported it, and we don't need it after moving to class-based scrapers.

This lets us remove some redundant functions, as well as unindent a big block of code.