### PR TITLE
fix: #426 time.clock() deprecated since python3.3

### DIFF
--- a/resources/lib/dbupdate.py
+++ b/resources/lib/dbupdate.py
@@ -174,7 +174,7 @@ class DBUpdate(object):
                     #Give kodi a chance to interrupt the process
                     #HACK: we should use monitor.abortRequested() or monitor.waitForAbort()
                     #but for some reason only xbmc.abortRequested returns True
-                    if monitor.abortRequested() or xbmc.abortRequested:
+                    if monitor.abortRequested():
                         log.info("Kodi requests abort. Cancel Update.")
                         break
 
@@ -229,7 +229,7 @@ class DBUpdate(object):
                     #Give kodi a chance to interrupt the process
                     #HACK: we should use monitor.abortRequested() or monitor.waitForAbort()
                     #but for some reason only xbmc.abortRequested returns True
-                    if monitor.abortRequested() or xbmc.abortRequested:
+                    if monitor.abortRequested():
                         log.info("Kodi requests abort. Cancel Update.")
                         break
 

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -832,7 +832,7 @@ class UIGameDB(xbmcgui.WindowXML):
 
         showFavoriteStars = self.Settings.getSetting(util.SETTING_RCB_SHOWFAVORITESTARS).upper() == 'TRUE'
 
-        timestamp1 = time.clock()
+        timestamp1 = time.process_time()
 
         likeStatement = self._getGamesListQueryStatement()
         order_by = "ORDER BY %s COLLATE NOCASE %s" %(self.sortMethod, self.sortDirection)
@@ -843,7 +843,7 @@ class UIGameDB(xbmcgui.WindowXML):
                                                 self.selectedMaxPlayers, self.selectedRating, self.selectedRegion,
                                                 isFavorite, likeStatement, order_by, maxNumGames)
 
-        timestamp2 = time.clock()
+        timestamp2 = time.process_time()
         diff = (timestamp2 - timestamp1) * 1000
         print ("showGames: load %d games from db in %d ms" % (len(games), diff))
 
@@ -950,7 +950,7 @@ class UIGameDB(xbmcgui.WindowXML):
             elif int(view_mode) in VIEWS_HORIZONTAL:
                 self.writeMsg(util.localize(32209))
 
-        timestamp3 = time.clock()
+        timestamp3 = time.process_time()
         diff = (timestamp3 - timestamp2) * 1000
         Logutil.log("showGames: load %i games to list in %d ms" % (self.getListSize(), diff), util.LOG_LEVEL_INFO)
 

--- a/resources/tests/test_db_gameview.py
+++ b/resources/tests/test_db_gameview.py
@@ -146,17 +146,17 @@ class TestDbGameView(unittest.TestCase):
         gdb.cursor.execute("PRAGMA cache_size = 20000")
 
         import time
-        timestamp1 = time.clock()
+        timestamp1 = time.process_time()
         games = GameView(gdb).getFilteredGames(0, 0, 0, 0, 0, 0, 0, 0, 0, '0 = 0', '', 0)
         #games = Game(gdb).getAll()
-        timestamp2 = time.clock()
+        timestamp2 = time.process_time()
         diff = (timestamp2 - timestamp1) * 1000
         print ("load %d games from db in %d ms" % (len(games), diff))
 
-        timestamp1 = time.clock()
+        timestamp1 = time.process_time()
         #Game(gdb).getGameById(5000)
         row = GameView(gdb).getGameById(5000)
-        timestamp2 = time.clock()
+        timestamp2 = time.process_time()
         diff = (timestamp2 - timestamp1) * 1000
         print ("load 1 game from db in %d ms" % diff)
 

--- a/resources/tests/test_imageloading.py
+++ b/resources/tests/test_imageloading.py
@@ -354,14 +354,14 @@ class Test(unittest.TestCase):
         pathToSearch = re.escape(os.path.normpath(pathnameFromFile.replace('.*', '')))
         foundImage = ''
                 
-        timestamp1 = time.clock()
+        timestamp1 = time.process_time()
         pattern = re.compile('%s\..*$' %re.escape(gamenameFromFile))
         for image in imagelist:
             match = pattern.search(image)
             if match:
                 foundImage = image
                 
-        timestamp2 = time.clock()
+        timestamp2 = time.process_time()
         diff = (timestamp2 - timestamp1) * 1000
         print ('pattern.search took %s ms' %diff)
         
@@ -374,10 +374,10 @@ class Test(unittest.TestCase):
         pathToSearch = re.escape(os.path.normpath(pathnameFromFile.replace('.*', '')))
         foundImage = ''
         
-        timestamp1 = time.clock()
+        timestamp1 = time.process_time()
         pattern = re.compile('%s\..*$' %pathToSearch)
         foundImage = list(filter(pattern.match, imagelist))
-        timestamp2 = time.clock()
+        timestamp2 = time.process_time()
         diff = (timestamp2 - timestamp1) * 1000
         print ('filter took %s ms' %diff)
                 


### PR DESCRIPTION
This commit replaces all time.clock() references for
time.process_time().

https://docs.python.org/3/library/time.html#time.process_time
"Value (in fractional seconds) of the sum of the system and user CPU
time of the current process"