### PR TITLE
[python] update xbmc.translatePath() to xbmcvfs

### DIFF
--- a/resources/lib/util.py
+++ b/resources/lib/util.py
@@ -206,7 +206,7 @@ def localize(string_id):
 
 def getAddonDataPath():
     path = u''
-    path = convertToUnicodeString(xbmc.translatePath('special://profile/addon_data/%s' % (SCRIPTID)))
+    path = convertToUnicodeString(xbmcvfs.translatePath('special://profile/addon_data/%s' % (SCRIPTID)))
 
     if not os.path.exists(path):
         try:


### PR DESCRIPTION
As per Alpha2 of Matrix. The correct syntax for xbmc.translatePath() is xbmcvfs.translatePath()