### PR TITLE
python 3 compatibility clean up

### DIFF
--- a/convert_skin_files.py
+++ b/convert_skin_files.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from builtins import str
 from builtins import object
 import os, sys, re

--- a/resources/lib/artworkupdater.py
+++ b/resources/lib/artworkupdater.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import str
 from builtins import object
 import os, re

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import next
 from builtins import str
 from builtins import object

--- a/resources/lib/configxmlupdater.py
+++ b/resources/lib/configxmlupdater.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 import os, shutil
 

--- a/resources/lib/configxmlwriter.py
+++ b/resources/lib/configxmlwriter.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 import os
 

--- a/resources/lib/dbupdate.py
+++ b/resources/lib/dbupdate.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from builtins import object
 import glob

--- a/resources/lib/dialogbase.py
+++ b/resources/lib/dialogbase.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from builtins import range
 import xbmc, xbmcgui

--- a/resources/lib/dialogcontextmenu.py
+++ b/resources/lib/dialogcontextmenu.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from builtins import range
 from builtins import object

--- a/resources/lib/dialogdeleteromcollection.py
+++ b/resources/lib/dialogdeleteromcollection.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from builtins import range
 import xbmc

--- a/resources/lib/dialogeditromcollection.py
+++ b/resources/lib/dialogeditromcollection.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from builtins import range
 import xbmc, xbmcgui

--- a/resources/lib/dialoggameinfo.py
+++ b/resources/lib/dialoggameinfo.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 import xbmc, xbmcgui
 import helper, util

--- a/resources/lib/dialogimportoptions.py
+++ b/resources/lib/dialogimportoptions.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from config import *
 from util import *

--- a/resources/lib/dialogmissinginfo.py
+++ b/resources/lib/dialogmissinginfo.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import range
 from configxmlwriter import *
 from util import *

--- a/resources/lib/dialogprogress.py
+++ b/resources/lib/dialogprogress.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import object
 import xbmcgui
 

--- a/resources/lib/dialogupdateartwork.py
+++ b/resources/lib/dialogupdateartwork.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from config import *
 from util import *

--- a/resources/lib/emulatorautoconfig/autoconfig.py
+++ b/resources/lib/emulatorautoconfig/autoconfig.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from builtins import next
 from builtins import str
 from builtins import object

--- a/resources/lib/gamedatabase.py
+++ b/resources/lib/gamedatabase.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 from builtins import range
 from builtins import object

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import chr
 from builtins import str
 from builtins import range

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 from builtins import chr
 from builtins import str
 from builtins import range
@@ -925,7 +924,7 @@ class UIGameDB(xbmcgui.WindowXML):
             #add progress to "loading games" message
             if len(games) > 1000:
                 if counter >= divisor and counter % divisor == 0:
-                    percent = (old_div(len(games), divisor)) * (old_div(counter, divisor))
+                    percent = (len(games) // divisor) * (counter // divisor)
                     #32121 = Loading games...
                     self.writeMsg('%s (%i%%)' % (util.localize(32121), percent))
                 counter = counter + 1

--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 import json
 import os, re

--- a/resources/lib/nfowriter.py
+++ b/resources/lib/nfowriter.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 import os
 import xml.etree.ElementTree as ET

--- a/resources/lib/pyscraper/file_scraper.py
+++ b/resources/lib/pyscraper/file_scraper.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from scraper import AbstractScraper
 
 

--- a/resources/lib/pyscraper/giantbomb_scraper.py
+++ b/resources/lib/pyscraper/giantbomb_scraper.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from web_scraper import WebScraper
 from rcbexceptions import *
 from util import Logutil as log

--- a/resources/lib/pyscraper/mame_scraper.py
+++ b/resources/lib/pyscraper/mame_scraper.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-from __future__ import absolute_import
 import re
 import os
 import xbmcvfs

--- a/resources/lib/pyscraper/matcher.py
+++ b/resources/lib/pyscraper/matcher.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-from __future__ import print_function
-from __future__ import absolute_import
 import sys
 print ("sys version: {0}".format(sys.version_info))
 if (sys.version_info > (3, 0)):

--- a/resources/lib/pyscraper/mobygames_scraper.py
+++ b/resources/lib/pyscraper/mobygames_scraper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from web_scraper import WebScraper
 from rcbexceptions import *
 from util import Logutil as log

--- a/resources/lib/pyscraper/nfo_scraper.py
+++ b/resources/lib/pyscraper/nfo_scraper.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 
 import xbmcvfs

--- a/resources/lib/pyscraper/offline_gdbi_scraper.py
+++ b/resources/lib/pyscraper/offline_gdbi_scraper.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
 import re
 import xml.etree.ElementTree as ET
 import xbmcvfs

--- a/resources/lib/pyscraper/thegamesdb_scraper.py
+++ b/resources/lib/pyscraper/thegamesdb_scraper.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import sys
 import xml.etree.ElementTree as ET
 from web_scraper import WebScraper

--- a/resources/lib/pyscraper/web_scraper.py
+++ b/resources/lib/pyscraper/web_scraper.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import requests
 from datetime import datetime
 import time

--- a/resources/lib/temptests.py
+++ b/resources/lib/temptests.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 
-from __future__ import absolute_import
 import os, sys, requests
 
 from config import *

--- a/resources/lib/util.py
+++ b/resources/lib/util.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from builtins import object
 import os

--- a/resources/lib/wizardconfigxml.py
+++ b/resources/lib/wizardconfigxml.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from builtins import str
 from xml.etree.ElementTree import *
 

--- a/resources/lib/xbmc.py
+++ b/resources/lib/xbmc.py
@@ -4,8 +4,6 @@
 """
 Various classes and functions to interact with Kodi.
 """
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 from builtins import object
 import os

--- a/resources/lib/xbmcaddon.py
+++ b/resources/lib/xbmcaddon.py
@@ -2,8 +2,6 @@
 """
 A class to access addon properties
 """
-from __future__ import print_function
-
 from builtins import str
 from builtins import object
 import os

--- a/resources/lib/xbmcgui.py
+++ b/resources/lib/xbmcgui.py
@@ -2,8 +2,6 @@
 """
 Classes and functions to work with Kodi GUI
 """
-from __future__ import absolute_import
-
 from builtins import str
 from builtins import object
 import xbmc as _xbmc


### PR DESCRIPTION
remove __future__ imports, no longer required for Python 3 (Matrix).  doesn't seem to cause issues but they are no longer needed.

change old_div to use integer division "//".  i believe this was provided via division import from __future__, but that no longer works apparently.
